### PR TITLE
implementation of message sending function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,7 @@ gem "font-awesome-sass"
 gem "devise"
 
 gem "pry-rails"
+
+gem 'carrierwave'
+
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,11 +38,20 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (7.1.4)
     bcrypt (3.1.15)
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.3)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -82,6 +91,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    image_processing (1.10.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -97,6 +109,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (1.0.0)
+    mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.1.0)
     mini_portile2 (2.5.1)
     minitest (5.14.4)
@@ -111,6 +125,7 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.5.2)
     rack (2.2.3)
@@ -146,6 +161,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_parser (3.15.1)
       sexp_processor (~> 4.9)
     sass (3.7.4)
@@ -200,6 +217,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   font-awesome-sass
@@ -207,6 +225,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   pry-rails
   puma (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ChatSpace DB設計
+
 ## users table
 |Column|Type|Options|
 |------|----|-------|
@@ -9,6 +10,7 @@
  - has_many :groups, through: :groups_users
  - has_many :groups_users
  - has_many :messages
+
 
 ## groups table
 |Column|Type|Options|

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,5 +8,7 @@
 @import "modules/messages";
 @import "font-awesome-sprockets";
 @import "font-awesome";
+// @import "modules/user";
 @import "modules/flash";
+// @import "modules/group";
 

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -2,8 +2,13 @@
   box-sizing: border-box;
 }
 
-.side-bar{
+.wrapper{
   height: 100vh;
+  width: 100vw;
+}
+
+.side-bar{
+  height: 100%;
   width: 300px;
   background-color: #253141;
   float: left;
@@ -20,13 +25,15 @@
     font-weight: bold;
     padding-top: 20px ;
     &--groups{
-      &--name{
-        margin: 0 20px 5px 20px;
-        font-size: 15px;
-      }
-      &--message{
-        margin: 0 20px 40px 20px;
-        font-size: 11px;
+      &--group{ 
+        &--name{
+          margin: 0 20px 5px 20px;
+          font-size: 15px;
+        }
+        &--message{
+          margin: 0 20px 40px 20px;
+          font-size: 11px;
+        }
       }
     }
   }
@@ -60,8 +67,9 @@ i{
   color: #ffffff;
 }
 
+
 .chat-main{
-  height: 100vh;
+  height: 100%;
   width: calc(100vw - 300px);
   background-color: #ffffff;
   float: left;
@@ -73,58 +81,106 @@ i{
     display: flex;
     justify-content: space-between;
     align-items: center;
-  }  
+    &--group-name{
+      &--members{
+        margin-top: 15px;
+        font-size: 12px;
+        display: flex;
+        &--member{
+          color: #999999;
+          font-size: 12px;
+        }
+        &--name{
+        }
+      }
+    }
+
+
+
+
+    &--edit{
+      height: 40px;
+      width: 60px;
+      font-size: 16px;
+      color: #38aef0;
+      line-height: 40px;
+      margin: 28px 20px;
+      border-style: solid;
+      border-width: thin;
+      text-align: center;
+      &--url{
+        color: #38aef0;
+        text-decoration: none;
+      }
+    }
+  }
+
+
+  
+
+
 
   &__message-list{
     height: calc(100% - 100px - 90px);
     background-color: #fafafa;
     padding-top: 35px;
     padding-left: 40px;
-    &--comment{
-      &--member-name{
+    box-sizing: border-box;
+    overflow: scroll;
+    &--name-day{
+      &--name{
         color: #333333;
         font-size: 16px;
         margin-bottom: 12px;
       }
-      &--comment{
+      &--day{
         color: #434a54;
         font-size: 14px;
         margin-bottom: 46px;
       }
-    }  
+    }
+    &--comment{
+      &--content{
+
+      }
+      &--image{
+
+      }
+    }
   }
+
   &__message-form{
     height: 90px;
-    background-color: #d2d2d2;
+    background-color: #d2d2d2d2;
     padding: 0 40px;
     display: flex;
     align-items: center;
-    &--type{
-      width: 100%;
-      height: 50px;
-      display: flex;
-      &--box{
+    justify-content: center;
+    &--box{
+      &--text-image{
+        background-color: blue;
+        height: 50px;
         width: 100%;
-        padding: 0 10px;
         position: relative;
         &--text{
-          width: 100%;
           height: 100%;
+          width: 100%;
+          padding: 0 10px;
         }
-        &--dialog{
-          width: 20px;
+        &--image{
           position: absolute;
-          bottom: 1px;
-          right: 1px;
-          font-size: 1px;
+          top: 10px;
+          right: 10px;
           &--icon{
+            font-size: 30px;
+            color: lightgray;
           }
-          &--except{
+          &--hidden{
             display: none;
           }
         }
       }
-      &--btn{
+      &--submit{
         width: 100px;
         margin-left: 15px;
       }
@@ -132,6 +188,11 @@ i{
   }
 }
 
+
+.chat_main__message-form--box{
+  display: flex;
+  width: 100%;
+}
 
 h2{ 
   font-size: 20px;
@@ -141,27 +202,6 @@ h2{
   flex-flow: column;
 }
 
-.group-name-member__group--member{
-  margin-top: 15px;
-  font-size: 12px;
-  &--member{
-    color: #999999;
-    font-size: 12px;
-    display: flex;
-    &--name{
-    }
-  }
-}
-
-.edit{
-  height: 40px;
-  width: 32px;
-  font-size: 16px;
-  color: #38aef0;
-  line-height: 40px;
-  margin: 28px 20px;
-  text-decoration: none;
-}
 
 .far.fa-image{
   position: absolute;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,10 +24,9 @@ class GroupsController < ApplicationController
     redirect_to root_path, notice: 'グループを更新しました'
   end
 
-
   private
   def group_params
     params.require(:group).permit(:name, user_ids: [])
   end
-  
+
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,29 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
   end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,15 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
+
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,9 @@
+class Message < ApplicationRecord
+
+ belongs_to :user
+ belongs_to :group
+
+ validates :content, presence: true, unless: :image?
+
+ mount_uploader :image, ImageUploader
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   has_many :group_users
   has_many :groups, through: :group_users
+  has_many :messages
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,50 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+
+  include CarrierWave::MiniMagick
+  process resize_to_fit: [800, 800]
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,51 +1,26 @@
--# <div class = "chat-main">
--# </div>
 .chat-main
+
   .chat-main__group-info
-    %h2.group-name-member__group
-      hasegawa's
-      .group-name-member__group--member
-        %ul.group-name-member__group--member--member
+    %h2.chat-main__group-info--group-name
+      = @group.name
+      %ul.chat-main__group-info--group-name--members
+        %li.chat-main__group-info--group-name--member--member
           Member :
-          %li.group-name-member__group--member--member--name
-            Doraemon
-    = link_to "#", class: "edit" do
-      edit
+        %li.chat-main__group-info--group-name--member--name
+          - @group.users.each do |user|
+            = user.name
+    .chat-main__group-info--edit
+      = link_to edit_group_path(@group.id), class:"chat-main__group-info--edit--url" do
+        Edit
 
   .chat-main__message-list
-    .chat-main__message-list--comment
-      .chat-main__message-list--comment--member-name
-        hasegawa 2021/05/12
-      .chat-main__message-list--comment--comment
-        おはよう
-
-  -# .chat-main__message-form
-  -#   %form.chat-main__message-form--type
-  -#     %input.chat-main__message-form--type--text{:placeholder => "type a message", :type => "text"}/
-  -#       %p.chat-main__message-form--type--text-box
-  -#       %i.far.fa-image
-  -#     %input.chat-main__message-form--type--btn{:name => "commit", :type => "submit", :value => "Send"}/
-
-
-
-  -# .chat-main__message-form
-  -#   %form.chat-main__message-form--type
-  -#     .chat-main__message-form--type--box
-  -#       %input.chat-main__message-form--type--box--text{placeholder: "type a message", type: "text"}
-  -#       %i.far.fa-image
-  -#       %input.chat-main__message-form--type--box--dialog{type: "file"}
-  -#     %input.chat-main__message-form--type--btn{name: "commit", type: "submit", value: "Send"}
-
-
-
-  
-
+    = render @messages
 
   .chat-main__message-form
-    %form.chat-main__message-form--type
-      .chat-main__message-form--type--box
-        %input.chat-main__message-form--type--box--text{placeholder: "type a message", type: "text"}
-        %label{class: "chat-main__message-form--type--box--dialog"}
-          = icon('far fa','image',class:"chat-main__message-form--type--box--dialog--icon")
-          %input{type: "file",class: "chat-main__message-form--type--box--dialog--except"}
-      %input.chat-main__message-form--type--btn{name: "commit", type: "submit", value: "Send"}
+    = form_for [@group, @message], html:{class: "chat_main__message-form--box"} do |f|
+      .chat-main__message-form--box--text-image
+        = f.text_field :content, class: "chat-main__message-form--box--text-image--text", placeholder: "type a message"
+        = f.label :image, class: 'chat-main__message-form--box--text-image--image' do
+          = icon('fas', 'image', class: 'chat-main__message-form--box--text-image--image--icon')
+          = f.file_field :image, class: 'chat-main__message-form--box--text-image--image--hidden'
+      = f.submit 'Send', class: "chat-main__message-form--box--submit"

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,25 @@
+.chat-main__message-list--name-day{"data-message-id": "#{message.id}"}
+  .chat-main__message-list--name-day--name
+    = message.user.name
+  .chat-main__message-list--name-day--day
+    = message.created_at.strftime("%Y/%m/%d %H:%M")
+.chat-main__message-list--comment
+  - if message.content.present?
+    %p.chat-main__message-list--comment--content
+      = message.content
+  = image_tag message.image.url, class: 'chat-main__message-list--comment--image' if message.image.present?
+
+
+
+
+-# .chat_main__message--list_name_date_message{"data-message-id": "#{message.id}"}
+-#   .chat_main__message--list_name_date_message_name_date
+-#     .chat_main__message--list_name_date_message_name_date_name
+-#       = message.user.name
+-#     .chat_main__message--list_name_date_message_name_date_date
+-#       = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+-#   .chat_main__message--list_name_date_message_message
+-#     - if message.content.present?
+-#       %p.lower-message__content
+-#         = message.content
+-#     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -25,3 +25,4 @@
           .side-bar__group-list--groups--group--name
             = group.name
           .side-bar__group-list--groups--group--message
+            = group.show_last_message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,3 +1,3 @@
 .wrapper
-  = render "side_bar"
-  = render "main_chat"
+  = render 'side_bar'
+  = render 'main_chat'

--- a/app/views/practice.html
+++ b/app/views/practice.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <div class = "aa">
+    <div class = "bb">
+      <div class = "cc">
+      </div>
+      <div class = "dd">
+      </div>
+      <div class = "ee">
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+
+
+<style>
+  .aa{
+    width: 600px;
+    height: 90px;
+    background-color: black;
+  }
+  .bb{
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
+  .cc{
+    width: 100px;
+    height: 50px;
+    background-color:  blue;
+  }
+  .dd{
+    height: 20px;
+    background-color: yellow;
+  }
+  .ee{
+    width: 100px;
+    height: 50px;
+    background-color: red;
+  }
+</style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
+  # root "groups#index"
   root "groups#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20210520105713_create_messages.rb
+++ b/db/migrate/20210520105713_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210517120133) do
+ActiveRecord::Schema.define(version: 20210520105713) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -28,6 +28,17 @@ ActiveRecord::Schema.define(version: 20210517120133) do
     t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
   end
 
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
+  end
+
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
@@ -43,4 +54,6 @@ ActiveRecord::Schema.define(version: 20210517120133) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# 大まかな実装内容

- メッセージのルーティングはグループにネストした形で行う
- メッセージ送信機能は、文章と画像を送れるようにする。
  - 画像の送信はCarrierWaveというGemを使用する。
  -（投稿した画像はアプリケーションのpublic以下に蓄積される）
  - 画像は、githubで管理する必要がないので、「.gitignoreにpublic/uploads/*」を記述
- バリデーション設定
  - validates :content, presence: true, unless: :image?
- 画像アップロード時の設定を行う為のアップローダーを作成
  - rails g uploader image
- image_uploaderをマウントする記述
  - mount_uploader :image, ImageUploader
- MiniMagickで画像リサイズが出来る様に記述する
  - image_uploader.rbに、MiniMagickを読み込んで、指定した設定で画像リサイズが出来る様に記述をします。app/uploaders/image_uploader.rbにinclude CarrierWave::MiniMagick process resize_to_fit: [800, 800]を記述
- messagesコントローラーのアクション(index,create)の主な流れ
  - private以下にdef set_groupを定義し、before_actionでset_groupを指定することで、コントローラー内で共通の「@group」を使えるようにする
  - indexアクションで、インスタンスである「@message」と、グループの全てのメッセージである「@messages」を定義する
- createアクションでは、メッセージの保存に成功した場合と失敗した場合（テキストも画像もない場合とか）の処理を分岐させる。
- サイドバーに最新のメッセージを表示する
- ヘッダーにグループ名とユーザー名が表示される
- グループ編集ページへのリンクの設定
- グループ編集後のリダイレクト先をメッセージ一覧にする


## 時間がかかってしまったこと
  - _main_chat.html.hamlが表示されず、render等記載方法に誤りがあると仮説を立て検証していたが、解決できない時間が続いた。
原因は、rootにアクセスした際、_side_bar.html.hamlのみが表示される仕様となっていたためだった。
作成するサービスの内容を理解できていなかったことが大きな原因であった。

  - form部分のビューが崩れてしまい改善まで多くの時間を費やしてしまった。
_main_chat.html.hamlのform部のscssを指定できていないことに気づいた。
前後の要素（親要素、子要素）は問題ないのに、formの箇所のみ指定できない謎の事象。
そのため、該当部分のセレクタのみを別途記述するかたちで対処することで対応した。