### PR TITLE
Implementing-asynchronous-communication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,9 +194,6 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -233,7 +230,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,64 @@
+$(function(){
+
+  function buildHTML(message) {
+    if ( message.image ){
+      var html =
+        `<div class = "chat-main__message-list--name-day" >
+          <div class = "chat-main__message-list--name-day--name" >
+            ${message.user_name}
+          </div>
+          <div class = "chat-main__message-list--name-day--day" >
+            ${message.created_at}
+          </div>
+        </div>
+        <div class= "chat-main__message-list--comment" >
+          <p class= "chat-main__message-list--comment--content" >
+            ${message.content}
+          </p>
+        <img src= ${message.image} >
+        </div>`
+    } else {
+      var html =
+        `<div class = "chat-main__message-list--name-day" >
+          <div class = "chat-main__message-list--name-day--name" >
+            ${message.user_name}
+          </div>
+          <div class = "chat-main__message-list--name-day--day" >
+            ${message.created_at}
+          </div>
+        </div>
+        <div class= "chat-main__message-list--comment" >
+          <p class= "chat-main__message-list--comment--content" >
+            ${message.content}
+          </p>
+        </div>`
+      }
+    $('.chat-main__message-list').append(html);
+  }
+
+  $("#new_message").on("submit", function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.chat-main__message-list').append(html);
+      $('.chat-main__message-list').animate({scrollTop: $('.chat-main__message-list')[0].scrollHeight}, 'fast');
+      $('form')[0].reset();
+    })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    })
+    return false;
+  })
+})
+
+

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -29,6 +29,7 @@
         &--name{
           margin: 0 20px 5px 20px;
           font-size: 15px;
+          text-decoration:none;
         }
         &--message{
           margin: 0 20px 40px 20px;
@@ -210,4 +211,10 @@ h2{
   z-index: 20;
   color: gray;
   font-size: 30px;
+}
+
+
+a{
+  color:inherit;  //linkのカラーはブラウザのデフォルトがある。左記記述により、親要素の色に合わせることができる
+  text-decoration:none;
 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,11 +9,13 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(params[:group_id]), notice: "メッセージを送信しました"}
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'
-      render :index
     end
   end
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,10 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title Chatspace02
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notification'
     = yield

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -23,4 +23,4 @@
         = f.label :image, class: 'chat-main__message-form--box--text-image--image' do
           = icon('fas', 'image', class: 'chat-main__message-form--box--text-image--image--icon')
           = f.file_field :image, class: 'chat-main__message-form--box--text-image--image--hidden'
-      = f.submit 'Send', class: "chat-main__message-form--box--submit"
+      = f.submit 'Send', class: "chat-main__message-form--box--submit", id: "new_message"

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -3,6 +3,7 @@
     = message.user.name
   .chat-main__message-list--name-day--day
     = message.created_at.strftime("%Y/%m/%d %H:%M")
+    
 .chat-main__message-list--comment
   - if message.content.present?
     %p.chat-main__message-list--comment--content

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -23,6 +23,6 @@
       - current_user.groups.each do |group|
         .side_bar__group-list--groups--group
           .side-bar__group-list--groups--group--name
-            = group.name
+            = link_to "#{group.name}", group_messages_path(current_user)
           .side-bar__group-list--groups--group--message
             = group.show_last_message

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.id @message.id
+json.content    @message.content
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.user_name @message.user.name
+json.image      @message.image.url

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,3 +1,5 @@
 .wrapper
   = render 'side_bar'
   = render 'main_chat'
+
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module Chatspace02
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
+
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# 非同期通信

**メッセージ送信機能実装のステップ**

Ⅰ. jqueryを使えるようにする

・gem ‘jquery-rails’

・message.jsをassets/javascriptsの配下に作成

・turbolinksを停止
	- gemをコメントアウト & bundle
	- application.html.hamlとapplication.jsからturbolinksを削除

※今回はturbolinksを削除する方法を採用したが、jsファイルでturbolinksを読み込むことで競合を避ける方法もある

Ⅱ. フォームが送信されたら、イベントが発火するようにする

Ⅲ. Ⅱのイベントが発火した時にAjaxを使用して、messages#createが動くようにする

Ⅳ. messages#createでメッセージを保存、respond_toを使用してHTMLとJSONの場合で処理を分ける

Ⅴ. jbuilderを使用して、作成したメッセージをJSON形式で返す

	jbuilderもviewと同じように該当するアクションと同じ名前にする必要がある

	※ターミナルのログでjbuilderが読み込まれた際に表示される下記の表示がなかった
	Rendering messages/create.json.jbuilder
	Rendered messages/create.json.jbuilder

	message.jsの変数定義をletを使っていたが、varに変えたところ表示されるようになった

Ⅵ. 返ってきたJSONをdoneメソッドで受け取り、HTMLを作成する

	非同期通信の結果として返ってくるデータは、done(function(引数) {処理})の関数の引数で受け取る

テンプレートリテラルを使用

Ⅶ. Ⅵで作成したHTMLをメッセージ画面の一番下に追加する
	append()を使う
	$('.messages').append(html);

Ⅷ. メッセージを送信したときに、メッセージ画面を最下部にスクロールする

    $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');   
	
	なお、下記の記述で投稿後の入力フォームの中を空にできる
    $('form')[0].reset();

Ⅸ. 連続で送信ボタンを押せるようにする
	一度投稿すると、送信ボタンが押せなくなってしまう仕様をキャンセルする
	return false;

	・return false
	jQueryの場合→親要素へのイベント伝播（バブリング）を止める
	JavaScriptの場合→親要素へのイベント伝播を止めない
	つまり、return falseでイベントの伝播を止めたい場合は、jQueryを使う必要がある。

Ⅹ. メッセージの送信に失敗した場合の処理も準備
	.fail(function(){
		alert(“メッセージ送信に失敗しました”);
	});

Ⅺ. 日時表示を日本時間に修正する
	railsのアプリケーションの時間基準は、デフォルトでは協定時（UTC）となっています。
	config/application.rbを修正
	config.time_zone = ’Tokyo’

■補足

・画像のみ、コメントと画像　の投稿をするとなぜか非同期にならなかった。
	→　message.jsのif ( message.image ){　の最後にreturn html;を記載していたためだった

■ポイント
非同期通信では、ビューの再描写は行わない

必要なデータを返し、返したデータをJavaScriptで処理しビューの一部を変更する

非同期で行われるリクエストに対して、求められたデータをレスポンスする仕組みを用意する必要がある⇔ API

通常、railsは必要なHTMLを組み立てて返すのが仕事

しかし、JSON形式でデータを返すようにすることもできる⇔ API もしくはJSON API

API機能をrailsに追加する方法はいくつかある

今回は元々あるコントローラーに対して非同期通信の場合には非同期通信のデータを返す実装を行う

respond_toでリクエストに含まれるレスポンスのフォーマットを指定する記述を元に条件分岐可能

JSONを返す場合、rubyのハッシュの状態のままrenderメソッドに渡すだけでJSONに変換してくれるため、コントローラーから直接データを返すことができる

よりわかりやすくするため、jbuilderを使用する

jbuilderを使用する＝ファイルを分割する
